### PR TITLE
refactor: use `let _` instead of `.unwrap_or(())`

### DIFF
--- a/svalin/src/test/integration/mod.rs
+++ b/svalin/src/test/integration/mod.rs
@@ -19,9 +19,9 @@ async fn integration_tests() {
     });
 
     // delete test dbs
-    std::fs::remove_file("./client.jammdb").unwrap_or(());
-    std::fs::remove_file("./server.jammdb").unwrap_or(());
-    std::fs::remove_file("./agent.jammdb").unwrap_or(());
+    let _ = std::fs::remove_file("./client.jammdb");
+    let _ = std::fs::remove_file("./server.jammdb");
+    let _ = std::fs::remove_file("./agent.jammdb");
 
     let host = "localhost:1234".to_owned();
 

--- a/svalin/src/test/integration/prepare_server.rs
+++ b/svalin/src/test/integration/prepare_server.rs
@@ -7,7 +7,7 @@ use crate::server::Server;
 pub async fn prepare_server() -> Result<Server> {
     let addr = "0.0.0.0:1234".to_socket_addrs().unwrap().next().unwrap();
     // delete the test db
-    std::fs::remove_file("./server_test.jammdb").unwrap_or(());
+    let _ = std::fs::remove_file("./server_test.jammdb");
     let db = marmelade::DB::open("./server_test.jammdb").expect("failed to open client db");
     let server = Server::prepare(
         addr,

--- a/svalin/src/test/integration/test_init.rs
+++ b/svalin/src/test/integration/test_init.rs
@@ -15,7 +15,7 @@ async fn test_init() {
     let server_handle = tokio::spawn(async move {
         let addr = "0.0.0.0:1234".to_socket_addrs().unwrap().next().unwrap();
         // delete the test db
-        std::fs::remove_file("./server_test.jammdb").unwrap_or(());
+        let _ = std::fs::remove_file("./server_test.jammdb");
         let db = marmelade::DB::open("./server_test.jammdb").expect("failed to open client db");
         let mut server = Server::prepare(addr, db.scope("default".into()).unwrap())
             .await
@@ -27,7 +27,7 @@ async fn test_init() {
     });
 
     // delete test client db
-    std::fs::remove_file("./client.jammdb").unwrap_or(());
+    let _ = std::fs::remove_file("./client.jammdb");
 
     let host = "localhost:1234".to_owned();
 


### PR DESCRIPTION
`let _ =` is more explicit to the reader that the success of a function is irrelevant.

Is there a reason why the test files don't take place in a temp directory?